### PR TITLE
A76xx: Rewrote https_post_file

### DIFF
--- a/.github/workflows/build_examples_platformio.yaml
+++ b/.github/workflows/build_examples_platformio.yaml
@@ -1,7 +1,11 @@
 name: Build Examples with PlatformIO
 
 # Triggers the workflow on push or pull request events
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -34,14 +38,20 @@ jobs:
             TINY_GSM_MODEM_SIM7000,
             TINY_GSM_MODEM_SIM7000SSL,
             TINY_GSM_MODEM_SIM7070,
+            TINY_GSM_MODEM_A7670,
             TINY_GSM_MODEM_UBLOX,
             TINY_GSM_MODEM_SARAR4,
             TINY_GSM_MODEM_XBEE,
             TINY_GSM_MODEM_SEQUANS_MONARCH,
+            # added in this fork
+            TINY_GSM_MODEM_A7608,
+            TINY_GSM_MODEM_A7670,
+            TINY_GSM_MODEM_SIM7020,
+            TINY_GSM_MODEM_SIM7672
           ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set variables
         run: |
@@ -54,7 +64,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -65,7 +75,7 @@ jobs:
           pip install --upgrade platformio
 
       - name: Restore or Cache Platforms and Libraries
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         id: cache_pio
         with:
           path: ~/.platformio
@@ -87,5 +97,5 @@ jobs:
           echo "${{ env.LIBRARY_INSTALL_SOURCE }}"
           pio lib --global install ${{ env.LIBRARY_INSTALL_SOURCE }}
           sed -i 's/\/\/ #define TINY_GSM_MODEM_SIM800/#define TINY_GSM_MODEM_SIM800/g' ${{ matrix.example }}/*
-          platformio ci --project-option='build_flags=-D ${{ env.TINYGSM_MODEM_TO_USE }}' --project-option='framework=arduino' --board=uno --board=leonardo --board=yun --board=megaatmega2560 --board=genuino101 --board=mkr1000USB --board=zero --board=teensy31 --board=bluepill_f103c8 --board=uno_pic32 --board=esp01 --board=nodemcuv2 --board=esp32dev
+          platformio ci --project-option='build_flags=-D ${{ env.TINYGSM_MODEM_TO_USE }}' --project-option='framework=arduino' --board=esp32dev --board=esp32s3box
           pio lib --global uninstall TinyGSM

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 .pio/*
 .clang_complete
 .gcc-flags.json
-platformio.ini
 extra_envs.ini
 lib/readme.txt
 include/readme.txt

--- a/library.json
+++ b/library.json
@@ -26,7 +26,9 @@
       "examples/*"
     ]
   },
-  "frameworks": ["arduino", "energia", "wiringpi"],
-  "platforms": "*",
+  "frameworks": "arduino",
+  "platforms": [
+    "espressif32"
+  ],
   "headers": "TinyGsmClient.h"
 }

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A small Arduino library for GPRS modules, that just works.
 paragraph=Includes examples for Blynk, MQTT, File Download, and Web Client. Supports many GSM, LTE, and WiFi modules with AT command interfaces.
 category=Communication
 url=https://github.com/vshymanskyy/TinyGSM
-architectures=*
+architectures=esp32
 includes=TinyGsmClient.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,10 +11,10 @@ monitor_filters = esp32_exception_decoder, log2file
 build_flags = 
   -Wall -Wextra -Wunused -Wmisleading-indentation -Wduplicated-cond -Wlogical-op -Wnull-dereference
   ; -D TINY_GSM_MODEM_SIM7000
-  -D TINY_GSM_MODEM_SIM7020
+  ; -D TINY_GSM_MODEM_SIM7020
   ; -D TINY_GSM_MODEM_SIM7600
   ; -D TINY_GSM_MODEM_A7608
-  ; -D TINY_GSM_MODEM_A7670
+  -D TINY_GSM_MODEM_A7670
   ; -D TINY_GSM_MODEM_SIM7672
 
 [env:esp32dev]

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,26 @@
+
+[platformio]
+lib_dir = .
+src_dir = tools/test_build
+
+[env]
+framework = arduino
+upload_protocol = esptool
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder, log2file
+build_flags = 
+  -Wall -Wextra -Wunused -Wmisleading-indentation -Wduplicated-cond -Wlogical-op -Wnull-dereference
+  ; -D TINY_GSM_MODEM_SIM7000
+  -D TINY_GSM_MODEM_SIM7020
+  ; -D TINY_GSM_MODEM_SIM7600
+  ; -D TINY_GSM_MODEM_A7608
+  ; -D TINY_GSM_MODEM_A7670
+  ; -D TINY_GSM_MODEM_SIM7672
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+
+[env:esp32s3box]
+platform = espressif32
+board = esp32s3box

--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -35,6 +35,7 @@ typedef TinyGsmSim7000::GsmClientSim7000 TinyGsmClient;
 #include "TinyGsmClientSIM7020.h"
 typedef TinyGsmSim7020                   TinyGsm;
 typedef TinyGsmSim7020::GsmClientSim7020 TinyGsmClient;
+typedef TinyGsmSim7020::GsmClientSecureSim7020 TinyGsmClientSecure;
 
 #elif defined(TINY_GSM_MODEM_SIM7000SSL)
 #include "TinyGsmClientSIM7000SSL.h"

--- a/src/TinyGsmClientA7670.h
+++ b/src/TinyGsmClientA7670.h
@@ -508,7 +508,7 @@ class TinyGsmA7670 : public TinyGsmModem<TinyGsmA7670>,
       waitResponse();
     }
     sendAT(GF("+CGNSSPWR=1"));  
-    if (waitResponse(10000UL,"+CGNSSPWR: READY!") != 1) { return false; }
+    if (waitResponse(10000UL, GF("+CGNSSPWR: READY!")) != 1) { return false; }
     return true;
   }
 

--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -488,7 +488,7 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     } 
     sendAT(GF("+CGPS=0"));
     if (waitResponse() != 1) { return false; }
-    return waitResponse(30000UL,"+CGPS: 0") == 1;
+    return waitResponse(30000UL,GF("+CGPS: 0")) == 1;
   }
 
   bool isEnableGPSImpl(){

--- a/src/TinyGsmHttpsA76xx.h
+++ b/src/TinyGsmHttpsA76xx.h
@@ -278,21 +278,19 @@ public:
     /**
      * @brief  POSTFile
      * @note   Send file to server
-     * @param  *filepath:File path and file name, full path required
+     * @param  *filepath:File path and file name, full path required. C:/file for local storage and D:/file for SD card
      * @param  method:  0 = GET 1 = POST 2 = HEAD 3 = DELETE
      * @param  sendFileAsBody: 0 = Send file as HTTP header and body , 1 = Send file as Body
      * @retval httpCode, -1 = failed
      */
     int https_post_file(const char *filepath, uint8_t method = 1, bool sendFileAsBody = 1)
     {
+        // A76XX Series_AT Command Manual_V1.09, Page 363
         // AT+HTTPPOSTFILE=<filename>[,<path>[,<method>[,<send_header>]]]
-        uint8_t path = 1;
-        if (!filepath)return -1;
-        if (&filepath[3] == NULL)return -1;
-        if (filepath[0] == 'd' || filepath[0] == 'D') {
-            path = 2;
-        }
-        thisModem().sendAT("+HTTPPOSTFILE=\"", &filepath[3], "\",", path, ',', method, ',', sendFileAsBody);
+        // filename: full path required. C:/file for local storage and D:/file for SD card
+        if (!filepath || strlen(filepath) < 4) return -1; // no file
+        uint8_t path = filepath[0] == 'd' || filepath[0] == 'D' ? 2 : 1; // storage (2 for SD or 1 for local)
+        thisModem().sendAT("+HTTPPOSTFILE=\"", filepath[3], "\",", path, ',', method, ',', sendFileAsBody);
         if (thisModem().waitResponse(120000UL) != 1) {
             return -1;
         }

--- a/tools/test_build/test_build.ino
+++ b/tools/test_build/test_build.ino
@@ -181,8 +181,9 @@ void loop() {
   int   hour      = 0;
   int   minute    = 0;
   int   second    = 0;
-  modem.getGPS(&latitude, &longitude);
-  modem.getGPS(&latitude, &longitude, &speed, &alt, &vsat, &usat, &acc, &year,
+  uint8_t status = 0;
+  modem.getGPS(&status, &latitude, &longitude);
+  modem.getGPS(&status, &latitude, &longitude, &speed, &alt, &vsat, &usat, &acc, &year,
                &month, &day, &hour, &minute, &second);
   modem.disableGPS();
 #endif


### PR DESCRIPTION
@lewisxhe: `https_post_file` leads to a compiler warning.  After close inspection, I am wondering if it is correctly written... There is no bound check and a comparison with a reference of a - maybe - character ?

So he is a proposed implementation which seems more correct to me and also fixes the warning.
 
```
In file included from src/TinyGsmClientA7670.h:30,
                 from src/TinyGsmClient.h:66,
                 from /Users/mat/Data/Workspace/forks/TinyGSM/tools/test_build/test_build.ino:7:
src/TinyGsmHttpsA76xx.h: In member function 'int TinyGsmHttpsA76xx<modemType>::https_post_file(const char*, uint8_t, bool)':
src/TinyGsmHttpsA76xx.h:291:26: warning: comparing the result of pointer addition '(filepath + 3)' and NULL [-Waddress]
  291 |         if (&filepath[3] == NULL)return -1;
      |                          ^
```


Same as other PR, the first commit includes #4 (CI) in order to get build feedback (which can be seen in my fork: https://github.com/mathieucarbou/lewisxhe-TinyGSM/actions).

 The commit relevant to this PR is the second one.