### PR TITLE
SIM7672/SIM7670G: add GsmClientSecureSIM7672 TLS socket + three bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,28 @@ Supports per-mux SSL certificate configuration via `setCertificate()`,
 
 `TinyGsmClient.h` now exposes `TinyGsmClientSecure` for `TINY_GSM_MODEM_SIM7670G`.
 
-> **Status:** implemented and builds; **awaiting on-device hardware test**.
-> `+CCHRECV` field order (`DATA,<session>,<len>` / `LEN,<len>,<session>`)
-> confirmed against `TinyGsmClientA76xxSSL.h` — Qualcomm vs ASR equivalence
-> unconfirmed until first hardware run.
+> **Status:** confirmed on hardware — T-SIM7670G-S3, firmware `SIM767XM5_B05V01_241206`.
+> All four TLS socket tests pass (example.com, ecc256.badssl.com, raw.githubusercontent.com,
+> 303 KB firmware download). End-to-end OTA via MQTT command confirmed working.
+>
+> `+CCHRECV` field order confirmed:
+> - `+CCHRECV: DATA,<session>,<len>` — `sslRead()`
+> - `+CCHRECV: LEN,<cache_len_0>,<cache_len_1>` — `sslAvailable()`
+
+Three bugs discovered and fixed during hardware validation (committed separately):
+
+- **`+CCH_PEER_CLOSED` data loss** — HTTP/1.0 servers send data and close in quick
+  succession. `sslAvailable()` called `sslConnected()` (→ `AT+CCHOPEN?`) first; by
+  the time that returned, the connection was gone and the buffer was never read. Fixed
+  with a `peer_closed[]` flag that bypasses the connected check and drains the buffer.
+
+- **`AT+CCHOPEN?` polled on every `maintain()` cycle** — hundreds of unnecessary
+  round-trips during a large download. Fixed: `sslAvailable()` now checks the
+  URC-maintained `sock_connected` flag instead of issuing `AT+CCHOPEN?`.
+
+- **`getLocalIPImpl()` returns AT echo with `StreamDebugger`** — `getLocalIP()`
+  returned `"AT+IPADDR+IPADDR: x.x.x.x"`. Fixed: parse `+IPADDR:` marker and
+  return just the address.
 
 #### 2. Runtime PSRAM detection (`TinyGsmCommon.h`)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,69 @@
 ![TinyGSM logo](https://cdn.rawgit.com/vshymanskyy/TinyGSM/d18e93dc51fe988a0b175aac647185457ef640b5/extras/logo.svg)
 
 A small Arduino library for GSM modules, that just works.
+
+---
+
+## This fork
+
+**Fork chain:** `zatalian/TinyGSM` → [`lewisxhe/TinyGSM-fork`](https://github.com/lewisxhe/TinyGSM-fork) → [`vshymanskyy/TinyGSM`](https://github.com/vshymanskyy/TinyGSM)
+
+### What lewisxhe added (upstream of this fork)
+
+- Full support for **A7670, A7608** (ASR-based SIMCom LTE modems)
+- Full support for **SIM7672 / SIM7670G** (Qualcomm-based, `TinyGsmClientSIM7672.h`)
+- **TLS socket for A76xx** (`TinyGsmClientA76xxSSL.h`) via `+CCH` AT commands
+- MQTT over TLS (`TinyGsmMqttA76xx.h`), HTTPS (`TinyGsmHttpsComm.h`), GPS extensions, filesystem
+
+### What this fork adds
+
+#### 1. `GsmClientSecureSIM7672` — TLS socket for SIM7670G
+
+The A76xxSSL TLS socket (`+CCH` commands) was not wired for SIM7670G —
+`modemConnect` was plain-TCP-only and `GsmClientSecure` was a commented-out
+TODO stub. This fork adds a full implementation in `TinyGsmClientSIM7672.h`:
+
+```cpp
+// Usage
+TinyGsmClientSecure client(modem, 0);  // mux 0 or 1
+client.connect("example.com", 443, 30);
+client.print("GET / HTTP/1.0\r\nHost: example.com\r\n\r\n");
+while (client.available()) Serial.write(client.read());
+client.stop();
+```
+
+Uses `+CCHSTART` / `+CCHOPEN` / `+CCHSEND` / `+CCHRECV` / `+CCHCLOSE`.
+Supports per-mux SSL certificate configuration via `setCertificate()`,
+`setClientCertificate()`, `setClientPrivateKey()`.
+
+`TinyGsmClient.h` now exposes `TinyGsmClientSecure` for `TINY_GSM_MODEM_SIM7670G`.
+
+> **Status:** implemented and builds; **awaiting on-device hardware test**.
+> `+CCHRECV` field order (`DATA,<session>,<len>` / `LEN,<len>,<session>`)
+> confirmed against `TinyGsmClientA76xxSSL.h` — Qualcomm vs ASR equivalence
+> unconfirmed until first hardware run.
+
+#### 2. Runtime PSRAM detection (`TinyGsmCommon.h`)
+
+`TINY_GSM_MALLOC` / `TINY_GSM_REALLOC` previously switched between
+`ps_malloc`/`ps_realloc` and plain `malloc`/`realloc` via the compile-time
+`BOARD_HAS_PSRAM` flag. On boards where PSRAM is wired but defective,
+`ps_malloc` returns `NULL` and MQTT silently never starts.
+
+On ESP32 targets, the flag is replaced with a runtime check:
+
+```cpp
+static inline bool tinygsm_has_psram() {
+    static const bool _psram = psramFound();
+    return _psram;
+}
+```
+
+`psramFound()` is called once at startup and cached. Falls back to plain
+`malloc` if PSRAM is absent or fails to initialise. The `-UBOARD_HAS_PSRAM`
+build flag workaround is no longer needed.
+
+---
 <!---
 [![GitHub download](https://img.shields.io/github/downloads/vshymanskyy/TinyGSM/total.svg)](https://github.com/vshymanskyy/TinyGSM/releases/latest)--->
 [![GitHub version](https://img.shields.io/github/release/vshymanskyy/TinyGSM.svg)](https://github.com/vshymanskyy/TinyGSM/releases/latest)
@@ -70,6 +133,8 @@ TinyGSM also pulls data gently from the modem (whenever possible), so it can ope
 - SIMCom LTE Modules (SIM7100E, SIM7500E, SIM7500A, SIM7600C, SIM7600E)
 - SIMCom SIM7000E/A/G CAT-M1/NB-IoT Module
 - SIMCom SIM7070/SIM7080/SIM7090 CAT-M1/NB-IoT Module
+- **SIMCom A7670 / A7608** (ASR-based LTE Cat-1) ← lewisxhe fork
+- **SIMCom SIM7672 / SIM7670G** (Qualcomm-based LTE Cat-M1/NB1/GPRS + GNSS) ← lewisxhe fork
 - AI-Thinker A6, A6C, A7, A20
 - ESP8266/ESP32 (AT commands interface, similar to GSM modems)
 - Digi XBee WiFi and Cellular (using XBee command mode)
@@ -127,6 +192,8 @@ Watch this repo for new updates! And of course, contributions are welcome ;)
     - Supported on:
         - SIM800, SIM7000, u-Blox, XBee _cellular_, ESP8266, and Sequans Monarch
         - Note:  **only some device models or firmware revisions have this feature** (SIM8xx R14.18, A7, etc.)
+        - **A7670 / A7608** — full TLS socket via `TinyGsmClientA76xxSSL` (`+CCH` commands) ← lewisxhe fork
+        - **SIM7672 / SIM7670G** — TLS socket via `GsmClientSecureSIM7672` (`+CCH` commands) ← **this fork** (awaiting hardware test)
     - Not yet supported on:
         - Quectel modems, SIM 5360/5320/7100, SIM 7500/7600/7800
     - Not possible on:

--- a/src/TinyGsmClient.h
+++ b/src/TinyGsmClient.h
@@ -82,8 +82,9 @@ typedef TinyGsmA7608                    TinyGsm;
 typedef TinyGsmA7608::GsmClientA7608 TinyGsmClient;
 #elif defined(TINY_GSM_MODEM_SIM7672) || defined(TINY_GSM_MODEM_SIM7670G)
 #include "TinyGsmClientSIM7672.h"
-typedef TinyGsmSim7672                   TinyGsm;
-typedef TinyGsmSim7672::GsmClientSim7672 TinyGsmClient;
+typedef TinyGsmSim7672                          TinyGsm;
+typedef TinyGsmSim7672::GsmClientSim7672        TinyGsmClient;
+typedef TinyGsmSim7672::GsmClientSecureSIM7672  TinyGsmClientSecure;
 #elif defined(TINY_GSM_MODEM_UBLOX)
 #include "TinyGsmClientUBLOX.h"
 typedef TinyGsmUBLOX                       TinyGsm;

--- a/src/TinyGsmClientSIM7672.h
+++ b/src/TinyGsmClientSIM7672.h
@@ -199,8 +199,9 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
    */
  public:
   explicit TinyGsmSim7672(Stream& stream) : stream(stream) {
-    memset(sockets, 0, sizeof(sockets));
-    memset(sslMode, 0, sizeof(sslMode));
+    memset(sockets,     0, sizeof(sockets));
+    memset(sslMode,     0, sizeof(sslMode));
+    memset(peer_closed, 0, sizeof(peer_closed));
   }
 
   /*
@@ -348,8 +349,17 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     // sendAT(GF("+CGPADDR=1"));  // Show PDP address
     String res;
     if (waitResponse(10000L, res) != 1) { return ""; }
-    res.replace(GSM_NL "OK" GSM_NL, "");
-    res.replace(GSM_NL, "");
+    // Response may include AT command echo (visible with StreamDebugger).
+    // Find the +IPADDR: marker and extract just the address.
+    int idx = res.indexOf("+IPADDR:");
+    if (idx >= 0) {
+      res = res.substring(idx + 8);
+      idx = res.indexOf('\r');
+      if (idx >= 0) res = res.substring(0, idx);
+    } else {
+      res.replace(GSM_NL "OK" GSM_NL, "");
+      res.replace(GSM_NL, "");
+    }
     res.trim();
     return res;
   }
@@ -1022,6 +1032,7 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
  protected:
   bool sslConnect(const char* host, uint16_t port, uint8_t mux, int timeout_s) {
     if (mux >= 2) { DBG("SSL mux must be 0 or 1"); return false; }
+    peer_closed[mux] = false;
     uint32_t timeout_ms = ((uint32_t)timeout_s) * 1000;
     uint8_t  authmode   = 0;
 
@@ -1116,7 +1127,11 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
 
   size_t sslAvailable(uint8_t mux) {
     if (!sockets[mux]) { return 0; }
-    if (!sslConnected(mux)) { return 0; }
+    // Use the URC-maintained sock_connected flag instead of AT+CCHOPEN? —
+    // eliminates one round-trip per maintain() cycle during active data transfer.
+    // sock_connected is set true by sslConnect() and false by +CCH_PEER_CLOSED.
+    // peer_closed allows draining the buffer after the server closes.
+    if (!sockets[mux]->sock_connected && !peer_closed[mux]) { return 0; }
     sendAT(GF("+CCHRECV?"));
     // +CCHRECV: LEN,<cache_len_0>,<cache_len_1>
     // Both fields are cache lengths for session 0 and 1 respectively.
@@ -1152,6 +1167,7 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
   }
 
   bool sslDisconnect(uint8_t mux) {
+    peer_closed[mux] = false;
     sendAT(GF("+CCHCLOSE="), mux);
     waitResponse(3000);
     waitResponse(3000UL, GF("+CCHCLOSE:"), GFP(GSM_ERROR));
@@ -1376,7 +1392,9 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
         } else if (data.endsWith(GF("+CCH_PEER_CLOSED:"))) {
           int8_t mux = streamGetIntBefore('\n');
           if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux]) {
-            sockets[mux]->sock_connected = false;
+            peer_closed[mux]              = true;  // buffer may still hold data
+            sockets[mux]->got_data        = true;  // trigger one final read attempt
+            sockets[mux]->sock_connected  = false;
             DBG("### SSL peer closed:", mux);
           }
           data = "";
@@ -1433,6 +1451,7 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
  protected:
   GsmClientSim7672* sockets[TINY_GSM_MUX_COUNT];
   bool              sslMode[TINY_GSM_MUX_COUNT];
+  bool              peer_closed[TINY_GSM_MUX_COUNT];  // set on +CCH_PEER_CLOSED; cleared on connect/disconnect
   String            certificates[TINY_GSM_MUX_COUNT];
   String            client_certificate[TINY_GSM_MUX_COUNT];
   String            client_private_key[TINY_GSM_MUX_COUNT];

--- a/src/TinyGsmClientSIM7672.h
+++ b/src/TinyGsmClientSIM7672.h
@@ -1097,14 +1097,15 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     if (!sockets[mux]) { return 0; }
     if (!sslConnected(mux)) { return 0; }
     sendAT(GF("+CCHRECV?"));
-    // +CCHRECV: LEN,<bytes>,<session_id>
+    // +CCHRECV: LEN,<cache_len_0>,<cache_len_1>
+    // Both fields are cache lengths for session 0 and 1 respectively.
+    // (SIM7672X SSL App Note §2.2.15 — NOT <len>,<session_id> as in A76xx)
     int res = waitResponse(3000, GF("+CCHRECV: LEN,"), GFP(GSM_OK), GFP(GSM_ERROR));
     if (res == 1) {
-      size_t result  = streamGetIntBefore(',');
-      int    ret_mux = streamGetIntBefore('\n');
-      if (ret_mux >= 0 && ret_mux < TINY_GSM_MUX_COUNT && sockets[ret_mux]) {
-        sockets[ret_mux]->sock_available = result;
-      }
+      size_t len0 = streamGetIntBefore(',');   // RX bytes cached for session 0
+      size_t len1 = streamGetIntBefore('\n');  // RX bytes cached for session 1
+      if (sockets[0]) sockets[0]->sock_available = len0;
+      if (sockets[1]) sockets[1]->sock_available = len1;
       waitResponse();
     }
     if (!sockets[mux]) { return 0; }
@@ -1359,7 +1360,12 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
           }
           data = "";
         } else if (data.endsWith(GF("+CCHEVENT:"))) {
-          streamSkipUntil('\n');  // e.g. "+CCHEVENT: 0,RECV EVENT"
+          // +CCHEVENT: <session_id>,RECV EVENT  (recv_mode=1 data-ready notification)
+          int8_t mux = streamGetIntBefore(',');
+          streamSkipUntil('\n');
+          if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux]) {
+            sockets[mux]->got_data = true;
+          }
           data = "";
         }
       }

--- a/src/TinyGsmClientSIM7672.h
+++ b/src/TinyGsmClientSIM7672.h
@@ -207,6 +207,27 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
    * Basic functions
    */
  protected:
+  // Called by modem.maintain() / GsmClient::available() when rx buffer is empty.
+  // Checks got_data flags set by +CCHEVENT (SSL) or +CIPRXGET (TCP) URCs and
+  // polls the modem for updated byte counts. Also drains any pending URCs.
+  void maintainImpl() {
+    bool check_socks = false;
+    for (int mux = 0; mux < TINY_GSM_MUX_COUNT; mux++) {
+      GsmClientSim7672* sock = sockets[mux];
+      if (sock && sock->got_data) {
+        sock->got_data = false;
+        check_socks    = true;
+      }
+    }
+    // modemGetAvailable dispatches per sslMode[]:
+    //   SSL  → sslAvailable()  → AT+CCHRECV? (updates both session slots at once)
+    //   TCP  → AT+CIPRXGET=4
+    // Calling for mux 0 is sufficient for SSL because sslAvailable() reads and
+    // updates both sessions (0 and 1) in a single AT+CCHRECV? response.
+    if (check_socks) { modemGetAvailable(0); }
+    while (stream.available()) { waitResponse(15, NULL, NULL); }
+  }
+
   bool initImpl(const char* pin = NULL) {
     DBG(GF("### TinyGSM Version:"), TINYGSM_VERSION);
     DBG(GF("### TinyGSM Compiled Module:  TinyGsmClientSIM7672"));

--- a/src/TinyGsmClientSIM7672.h
+++ b/src/TinyGsmClientSIM7672.h
@@ -150,9 +150,8 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
 
     void stop(uint32_t maxWaitMs) {
       dumpModemBuffer(maxWaitMs);
-      at->sendAT(GF("+CIPCLOSE="), mux);
+      at->modemDisconnect(mux);
       sock_connected = false;
-      at->waitResponse();
     }
     void stop() override {
       stop(15000L);
@@ -166,20 +165,25 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
   };
 
   /*
-   * Inner Secure Client
+   * Inner Secure Client — TLS via +CCH SSL-channel commands (SIM7672X SSL App Note)
    */
+  class GsmClientSecureSIM7672 : public GsmClientSim7672 {
+   public:
+    GsmClientSecureSIM7672() {}
 
-  /*TODO(?))
-  class GsmClientSecureSIM7672 : public GsmClientSim7672
-  {
-  public:
-    GsmClientSecure() {}
+    explicit GsmClientSecureSIM7672(TinyGsmSim7672& modem, uint8_t mux = 0)
+        : GsmClientSim7672(modem, mux) {}
 
-    GsmClientSecure(TinyGsmSim7672& modem, uint8_t mux = 0)
-     : public GsmClient(modem, mux)
-    {}
+    bool setCertificate(const String& certificateName) {
+      return at->setCertificate(certificateName, mux);
+    }
+    bool setClientCertificate(const String& clientCertFile) {
+      return at->setClientCertificate(clientCertFile, mux);
+    }
+    bool setClientPrivateKey(const String& clientKeyFile) {
+      return at->setClientPrivateKey(clientKeyFile, mux);
+    }
 
-  public:
     int connect(const char* host, uint16_t port, int timeout_s) override {
       stop();
       TINY_GSM_YIELD();
@@ -189,7 +193,6 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     }
     TINY_GSM_CLIENT_CONNECT_OVERRIDES
   };
-  */
 
   /*
    * Constructor
@@ -197,6 +200,7 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
  public:
   explicit TinyGsmSim7672(Stream& stream) : stream(stream) {
     memset(sockets, 0, sizeof(sockets));
+    memset(sslMode, 0, sizeof(sslMode));
   }
 
   /*
@@ -967,12 +971,186 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
   }
 
   /*
+   * SSL certificate helpers
+   */
+ protected:
+  bool setCertificate(const String& certificateName, const uint8_t mux = 0) {
+    if (mux >= TINY_GSM_MUX_COUNT) return false;
+    certificates[mux] = certificateName;
+    return true;
+  }
+  bool setClientCertificate(const String& clientCertFile, const uint8_t mux = 0) {
+    if (mux >= TINY_GSM_MUX_COUNT) return false;
+    client_certificate[mux] = clientCertFile;
+    return true;
+  }
+  bool setClientPrivateKey(const String& clientKeyFile, const uint8_t mux = 0) {
+    if (mux >= TINY_GSM_MUX_COUNT) return false;
+    client_private_key[mux] = clientKeyFile;
+    return true;
+  }
+
+  /*
+   * +CCH SSL-channel socket methods (SIM7672X/SIM7652X SSL Application Note)
+   * Sessions 0–1 only; uses the same AT+CSSLCFG / AT+CCH* commands as A76xx.
+   * NOTE: exact URC framing (+CCHRECV: LEN/DATA field order) needs on-device
+   *       verification against this modem's firmware. If mismatched, adjust
+   *       sslRead() and sslAvailable() accordingly.
+   */
+ protected:
+  bool sslConnect(const char* host, uint16_t port, uint8_t mux, int timeout_s) {
+    if (mux >= 2) { DBG("SSL mux must be 0 or 1"); return false; }
+    uint32_t timeout_ms = ((uint32_t)timeout_s) * 1000;
+    uint8_t  authmode   = 0;
+
+    sendAT(GF("+CSSLCFG=\"sslversion\","), mux, GF(",4"));  // TLS any version
+    if (waitResponse(5000L) != 1) return false;
+
+    sendAT(GF("+CSSLCFG=\"enableSNI\","), mux, ',', 1);
+    waitResponse(5000L);
+
+    if (certificates[mux] != "") {
+      sendAT(GF("+CSSLCFG=\"cacert\","), mux, ',', GF("\""),
+             certificates[mux].c_str(), GF("\""));
+      if (waitResponse(5000L) != 1) return false;
+      authmode = 1;
+    }
+    if (client_certificate[mux] != "") {
+      sendAT(GF("+CSSLCFG=\"clientcert\","), mux, ',', GF("\""),
+             client_certificate[mux].c_str(), GF("\""));
+      if (waitResponse(5000L) != 1) return false;
+    }
+    if (client_private_key[mux] != "") {
+      sendAT(GF("+CSSLCFG=\"clientkey\","), mux, ',', GF("\""),
+             client_private_key[mux].c_str(), GF("\""));
+      if (waitResponse(5000L) != 1) return false;
+    }
+    if (client_certificate[mux] != "" && client_private_key[mux] != "") {
+      authmode = 2;
+    }
+
+    sendAT(GF("+CSSLCFG=\"authmode\","), mux, ',', authmode);
+    waitResponse();
+
+    sendAT(GF("+CCHSET=1,1"));  // report mode: recv event URC enabled
+    waitResponse();
+
+    sendAT(GF("+CCHSTART"));    // start CCH service, activate PDP context
+    waitResponse(10000L);
+
+    sendAT(GF("+CCHSSLCFG="), mux, ',', mux);  // bind SSL ctx to session
+    waitResponse();
+
+    // AT+CCHOPEN=<session_id>,<host>,<port>,<client_type>
+    // client_type 2 = SSL/TLS
+    sendAT(GF("+CCHOPEN="), mux, GF(",\""), host, GF("\","), port, GF(",2"));
+    if (waitResponse(timeout_ms, GF(GSM_NL "+CCHOPEN:")) != 1) { return false; }
+    streamSkipUntil(',');  // skip session_id
+    int8_t res = streamGetIntBefore('\n');
+    waitResponse();
+    return res == 0;
+  }
+
+  int16_t sslSend(const void* buff, size_t len, uint8_t mux) {
+    sendAT(GF("+CCHSEND="), mux, ',', (uint16_t)len);
+    if (waitResponse(GF(">")) != 1) { return 0; }
+    stream.write(reinterpret_cast<const uint8_t*>(buff), len);
+    stream.flush();
+    // +CCHSEND: <session_id>,<err>   err=0 means success
+    if (waitResponse(GF(GSM_NL "+CCHSEND:")) != 1) { return 0; }
+    streamSkipUntil(',');  // skip session_id
+    return streamGetIntBefore('\n') == 0 ? (int16_t)len : 0;
+  }
+
+  size_t sslRead(size_t size, uint8_t mux) {
+    if (!sockets[mux]) { return 0; }
+    sendAT(GF("+CCHRECV="), mux, ',', (uint16_t)size);
+    // +CCHRECV: DATA,<session_id>,<len>
+    int8_t res = waitResponse(30000UL, GF("+CCHRECV: DATA,"), GF("ERROR"));
+    if (res != 1) { delay(100); return 0; }
+    uint8_t       ret_mux       = streamGetIntBefore(',');
+    const int16_t len_confirmed = streamGetIntBefore('\n');
+    if (ret_mux != mux) {
+      waitResponse();
+      sockets[mux]->sock_available = modemGetAvailable(mux);
+      return 0;
+    }
+    for (int i = 0; i < len_confirmed; i++) {
+      uint32_t startMillis = millis();
+      while (!stream.available() &&
+             (millis() - startMillis < sockets[mux]->_timeout)) {
+        TINY_GSM_YIELD();
+      }
+      sockets[mux]->rx.put(stream.read());
+    }
+    // trailing +CCHRECV: <session_id>,<remaining>
+    if (waitResponse(GF("+CCHRECV:")) == 1) {
+      streamSkipUntil(',');
+      streamSkipUntil('\n');
+    }
+    sockets[mux]->sock_available = modemGetAvailable(mux);
+    return len_confirmed;
+  }
+
+  size_t sslAvailable(uint8_t mux) {
+    if (!sockets[mux]) { return 0; }
+    if (!sslConnected(mux)) { return 0; }
+    sendAT(GF("+CCHRECV?"));
+    // +CCHRECV: LEN,<bytes>,<session_id>
+    int res = waitResponse(3000, GF("+CCHRECV: LEN,"), GFP(GSM_OK), GFP(GSM_ERROR));
+    if (res == 1) {
+      size_t result  = streamGetIntBefore(',');
+      int    ret_mux = streamGetIntBefore('\n');
+      if (ret_mux >= 0 && ret_mux < TINY_GSM_MUX_COUNT && sockets[ret_mux]) {
+        sockets[ret_mux]->sock_available = result;
+      }
+      waitResponse();
+    }
+    if (!sockets[mux]) { return 0; }
+    return sockets[mux]->sock_available;
+  }
+
+  bool sslConnected(uint8_t mux) {
+    sendAT(GF("+CCHOPEN?"));
+    // +CCHOPEN: <session_id>,<host>,<port>,<client_type>,<bind_port>
+    int res = waitResponse(3000, GF("+CCHOPEN:"), GFP(GSM_OK), GFP(GSM_ERROR));
+    if (res == 1) {
+      char buf[4] = {0};
+      int  ret_mux = streamGetIntBefore(',');
+      streamGetLength(buf, 2);
+      bool connected = (buf[0] == '"' && buf[1] != '"');
+      if (ret_mux == mux && sockets[mux]) {
+        sockets[mux]->sock_connected = connected;
+      }
+      waitResponse();
+    }
+    if (!sockets[mux]) return false;
+    return sockets[mux]->sock_connected;
+  }
+
+  bool sslDisconnect(uint8_t mux) {
+    sendAT(GF("+CCHCLOSE="), mux);
+    waitResponse(3000);
+    waitResponse(3000UL, GF("+CCHCLOSE:"), GFP(GSM_ERROR));
+    streamSkipUntil('\n');
+    sendAT(GF("+CCHSTOP"));
+    waitResponse(3000UL, GF("+CCHSTOP:"), GFP(GSM_ERROR));
+    streamSkipUntil('\n');
+    return true;
+  }
+
+  /*
    * Client related functions
    */
  protected:
   bool modemConnect(const char* host, uint16_t port, uint8_t mux,
                     bool ssl = false, int timeout_s = 15) {
-    if (ssl) { DBG("SSL not yet supported on this module!"); }
+    if (ssl) {
+      sslMode[mux] = true;
+      return sslConnect(host, port, mux, timeout_s);
+    }
+    sslMode[mux] = false;
+
     // Make sure we'll be getting data manually on this connection
     sendAT(GF("+CIPRXGET=1"));
     if (waitResponse() != 1) { return false; }
@@ -991,6 +1169,8 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
   }
 
   int16_t modemSend(const void* buff, size_t len, uint8_t mux) {
+    if (sslMode[mux]) return sslSend(buff, len, mux);
+
     sendAT(GF("+CIPSEND="), mux, ',', (uint16_t)len);
     if (waitResponse(GF(">")) != 1) { return 0; }
     stream.write(reinterpret_cast<const uint8_t*>(buff), len);
@@ -998,12 +1178,13 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     if (waitResponse(GF(GSM_NL "+CIPSEND:")) != 1) { return 0; }
     streamSkipUntil(',');  // Skip mux
     streamSkipUntil(',');  // Skip requested bytes to send
-    // TODO(?):  make sure requested and confirmed bytes match
     return streamGetIntBefore('\n');
   }
 
   size_t modemRead(size_t size, uint8_t mux) {
     if (!sockets[mux]) return 0;
+    if (sslMode[mux]) return sslRead(size, mux);
+
 #ifdef TINY_GSM_USE_HEX
     sendAT(GF("+CIPRXGET=3,"), mux, ',', (uint16_t)size);
     if (waitResponse(GF("+CIPRXGET:")) != 1) { return 0; }
@@ -1012,11 +1193,9 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     if (waitResponse(GF("+CIPRXGET:")) != 1) { return 0; }
 #endif
     streamSkipUntil(',');  // Skip Rx mode 2/normal or 3/HEX
-    streamSkipUntil(',');  // Skip mux/cid (connecion id)
+    streamSkipUntil(',');  // Skip mux/cid
     int16_t len_requested = streamGetIntBefore(',');
-    //  ^^ Requested number of data bytes (1-1460 bytes)to be read
     int16_t len_confirmed = streamGetIntBefore('\n');
-    // ^^ The data length which not read in the buffer
     for (int i = 0; i < len_requested; i++) {
       uint32_t startMillis = millis();
 #ifdef TINY_GSM_USE_HEX
@@ -1024,9 +1203,7 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
              (millis() - startMillis < sockets[mux]->_timeout)) {
         TINY_GSM_YIELD();
       }
-      char buf[4] = {
-          0,
-      };
+      char buf[4] = {0};
       buf[0] = stream.read();
       buf[1] = stream.read();
       char c = strtol(buf, NULL, 16);
@@ -1039,8 +1216,6 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
 #endif
       sockets[mux]->rx.put(c);
     }
-    // DBG("### READ:", len_requested, "from", mux);
-    // sockets[mux]->sock_available = modemGetAvailable(mux);
     sockets[mux]->sock_available = len_confirmed;
     waitResponse();
     return len_requested;
@@ -1048,6 +1223,8 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
 
   size_t modemGetAvailable(uint8_t mux) {
     if (!sockets[mux]) return 0;
+    if (sslMode[mux]) return sslAvailable(mux);
+
     sendAT(GF("+CIPRXGET=4,"), mux);
     size_t result = 0;
     if (waitResponse(GF("+CIPRXGET:")) == 1) {
@@ -1056,12 +1233,13 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
       result = streamGetIntBefore('\n');
       waitResponse();
     }
-    // DBG("### Available:", result, "on", mux);
     if (!result) { sockets[mux]->sock_connected = modemGetConnected(mux); }
     return result;
   }
 
   bool modemGetConnected(uint8_t mux) {
+    if (sslMode[mux]) return sslConnected(mux);
+
     // Read the status of all sockets at once
     sendAT(GF("+CIPCLOSE?"));
     if (waitResponse(GF("+CIPCLOSE:")) != 1) {
@@ -1075,6 +1253,14 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
     waitResponse();  // Should be an OK at the end
     if (!sockets[mux]) return false;
     return sockets[mux]->sock_connected;
+  }
+
+  bool modemDisconnect(uint8_t mux) {
+    if (sslMode[mux]) return sslDisconnect(mux);
+    sendAT(GF("+CIPCLOSE="), mux);
+    bool ok = waitResponse() == 1;
+    sslMode[mux] = false;
+    return ok;
   }
 
   /*
@@ -1164,6 +1350,16 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
           DBG("### Network error!");
           if (!isGprsConnected()) { gprsDisconnect(); }
           data = "";
+        } else if (data.endsWith(GF("+CCH_PEER_CLOSED:"))) {
+          int8_t mux = streamGetIntBefore('\n');
+          if (mux >= 0 && mux < TINY_GSM_MUX_COUNT && sockets[mux]) {
+            sockets[mux]->sock_connected = false;
+            DBG("### SSL peer closed:", mux);
+          }
+          data = "";
+        } else if (data.endsWith(GF("+CCHEVENT:"))) {
+          streamSkipUntil('\n');  // e.g. "+CCHEVENT: 0,RECV EVENT"
+          data = "";
         }
       }
     } while (millis() - startMillis < timeout_ms);
@@ -1208,6 +1404,11 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
 
  protected:
   GsmClientSim7672* sockets[TINY_GSM_MUX_COUNT];
+  bool              sslMode[TINY_GSM_MUX_COUNT];
+  String            certificates[TINY_GSM_MUX_COUNT];
+  String            client_certificate[TINY_GSM_MUX_COUNT];
+  String            client_private_key[TINY_GSM_MUX_COUNT];
+  String            client_private_key_password[TINY_GSM_MUX_COUNT];
   const char*       gsmNL = GSM_NL;
 };
 

--- a/src/TinyGsmClientSIM7672.h
+++ b/src/TinyGsmClientSIM7672.h
@@ -993,9 +993,10 @@ class TinyGsmSim7672 : public TinyGsmModem<TinyGsmSim7672>,
   /*
    * +CCH SSL-channel socket methods (SIM7672X/SIM7652X SSL Application Note)
    * Sessions 0–1 only; uses the same AT+CSSLCFG / AT+CCH* commands as A76xx.
-   * NOTE: exact URC framing (+CCHRECV: LEN/DATA field order) needs on-device
-   *       verification against this modem's firmware. If mismatched, adjust
-   *       sslRead() and sslAvailable() accordingly.
+   * Field order confirmed against TinyGsmClientA76xxSSL.h (same +CCH command set):
+   *   DATA response: +CCHRECV: DATA,<session>,<len>   (session first)
+   *   LEN  response: +CCHRECV: LEN,<len>,<session>    (len first)
+   * Qualcomm (SIM7670G) vs ASR (A76xx) equivalence unconfirmed until hardware test.
    */
  protected:
   bool sslConnect(const char* host, uint16_t port, uint8_t mux, int timeout_s) {

--- a/src/TinyGsmCommon.h
+++ b/src/TinyGsmCommon.h
@@ -32,12 +32,32 @@
 #define TINY_GSM_YIELD_MS 0
 #endif
 
+#if defined(ESP32)
+// Runtime PSRAM detection: checked once at first use, cached for subsequent calls.
+static inline bool tinygsm_has_psram() {
+    static const bool _psram = psramFound();
+    return _psram;
+}
+static inline void* tinygsm_malloc(size_t size) {
+    void* p = nullptr;
+    if (tinygsm_has_psram()) p = ps_malloc(size);
+    return p ? p : malloc(size);
+}
+static inline void* tinygsm_realloc(void* ptr, size_t size) {
+    if (tinygsm_has_psram()) return ps_realloc(ptr, size);
+    return realloc(ptr, size);
+}
+#define TINY_GSM_MALLOC  tinygsm_malloc
+#define TINY_GSM_REALLOC tinygsm_realloc
+#else
+// Non-ESP32: keep existing compile-time BOARD_HAS_PSRAM behaviour.
 #ifdef BOARD_HAS_PSRAM
 #define TINY_GSM_MALLOC       ps_malloc
 #define TINY_GSM_REALLOC      ps_realloc
 #else
 #define TINY_GSM_MALLOC       malloc
 #define TINY_GSM_REALLOC      realloc
+#endif
 #endif
 
 


### PR DESCRIPTION
## Summary

Adds a complete TLS socket implementation for the SIM7672/SIM7670G (Qualcomm-based) modems, plus three bugs discovered during hardware validation.

Tested on: **LilyGO T-SIM7670G-S3**, firmware **SIM767XM5_B05V01_241206**.

---

### 1. `GsmClientSecureSIM7672` — TLS socket via `+CCH` commands

`GsmClientSecure` was a commented-out TODO stub in `TinyGsmClientSIM7672.h`. This PR adds a full implementation modelled on the existing `TinyGsmClientA76xxSSL.h` (same `+CCH` AT command set).

```cpp
TinyGsmClientSecure client(modem, 0);  // mux 0 or 1
client.connect("example.com", 443, 30);
client.print("GET / HTTP/1.0\r\nHost: example.com\r\n\r\n");
while (client.available()) Serial.write(client.read());
client.stop();
```

Uses `+CCHSTART` / `+CCHOPEN` / `+CCHSEND` / `+CCHRECV` / `+CCHCLOSE` / `+CCHSTOP`.  
Supports per-mux SSL cert config via `setCertificate()`, `setClientCertificate()`, `setClientPrivateKey()`.

`TinyGsmClient.h` now exposes `TinyGsmClientSecure` for `TINY_GSM_MODEM_SIM7670G`.

**Hardware results:**
| Test | Bytes | Result |
|---|---|---|
| `example.com:443` | 798 B | PASS |
| `ecc256.badssl.com:443` (ECDSA + AES-GCM) | 951 B | PASS |
| `raw.githubusercontent.com:443` | 6,514 B | PASS |
| `pazuzu.vichogent.be:443` (firmware binary) | 303,876 B | PASS |

End-to-end OTA (MQTT-triggered, 303 KB download → flash → reboot) confirmed working.

`+CCHRECV` field order confirmed on this firmware:
- `+CCHRECV: DATA,<session>,<len>` — used by `sslRead()`
- `+CCHRECV: LEN,<cache_len_0>,<cache_len_1>` — used by `sslAvailable()`

---

### 2. Bug: `+CCH_PEER_CLOSED` data loss (`sslAvailable`)

HTTP/1.0 servers send data and immediately close. `+CCHEVENT` (data ready) and `+CCH_PEER_CLOSED` arrive back-to-back. `sslAvailable()` called `sslConnected()` → `AT+CCHOPEN?` first; by the time that returned, the connection appeared gone and we returned 0 bytes without reading the modem's RX buffer.

**Fix:** add `peer_closed[TINY_GSM_MUX_COUNT]` flag. Set on `+CCH_PEER_CLOSED` URC (also sets `got_data` to trigger one final read attempt), cleared on connect/disconnect. `sslAvailable()` skips the connected check when `peer_closed` is set and queries `AT+CCHRECV?` directly.

---

### 3. Bug: `AT+CCHOPEN?` polled on every `maintain()` cycle

`sslAvailable()` called `sslConnected()` (→ `AT+CCHOPEN?` round-trip) on every `maintain()` cycle — hundreds of unnecessary AT queries during a 303 KB download.

**Fix:** replace the `sslConnected()` call in `sslAvailable()` with a check on `sock_connected`, which is kept accurate by the `+CCH_PEER_CLOSED` URC and set true by `modemConnect()`. `sslConnected()` (with its `AT+CCHOPEN?`) is preserved for explicit use.

---

### 4. Bug: `getLocalIPImpl()` returns AT echo with `StreamDebugger`

With `DUMP_AT_COMMANDS` / `StreamDebugger` active, `waitResponse()` captured the echoed AT command, so `getLocalIP()` returned `"AT+IPADDR+IPADDR: x.x.x.x"`.

**Fix:** parse the `+IPADDR:` marker from the captured string and return just the address.

---

### Notes

- The SIM7670G is **Qualcomm**-based. The A7670/A7608 are ASR-based. The `+CCH` command set appears identical, but fixes for one chip family should be verified on the other before assuming equivalence.
- `maintainImpl()` (also in this branch, committed earlier) is required for SSL data receive — without it, `client.available()` never triggers `modemGetAvailable()` so `sock_available` stays 0 and all read loops time out.
- Runtime PSRAM detection (`tinygsm_has_psram()` in `TinyGsmCommon.h`) is also included — replaces the compile-time `-DBOARD_HAS_PSRAM` flag with a `psramFound()` call cached at startup.